### PR TITLE
bugfix: interchanged sematics of 'left' and 'right' values of parameter 'word'

### DIFF
--- a/R/subcorpusWord.R
+++ b/R/subcorpusWord.R
@@ -44,8 +44,8 @@ subcorpusWord <- function(object, text, search, ignore.case = FALSE,
         if(ignore.case) search[[i]]$pattern <- tolower(search[[i]]$pattern)
         if(is.logical(search[[i]]$word))search[[i]]$word <- c("pattern", "word")[search[[i]]$word+1]
         search[[i]]$pattern[search[[i]]$word == "word"] <- paste0("\\b",search[[i]]$pattern[search[[i]]$word == "word"], "\\b")
-        search[[i]]$pattern[search[[i]]$word == "left"] <- paste0("\\b",search[[i]]$pattern[search[[i]]$word == "left"])
-        search[[i]]$pattern[search[[i]]$word == "right"] <- paste0(search[[i]]$pattern[search[[i]]$word == "right"], "\\b")
+        search[[i]]$pattern[search[[i]]$word == "left"] <- paste0(search[[i]]$pattern[search[[i]]$word == "left"],"\\b")
+        search[[i]]$pattern[search[[i]]$word == "right"] <- paste0("\\b",search[[i]]$pattern[search[[i]]$word == "right"])
         counts <- NULL
 
         for(j in 1:nrow(search[[i]])){


### PR DESCRIPTION
The semantic of the keyword 'left' indicates the word boundary shall be on the right side of the pattern specified i.e. the pattern is open to the left side. However, currently the implementation implements interchanged semantics for 'left' and 'right'.